### PR TITLE
Small changes to the Makefile to harmonize with the way it is done in other repositories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
+NAME := fluentd
+DOCKER_ORG := digitalocean
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null)
-BASE_IMAGE_URL := digitalocean/fluentd
+
+BASE_IMAGE_URL := $(DOCKER_ORG)/$(NAME)
 IMAGE_URL := $(BASE_IMAGE_URL):$(GIT_COMMIT)
 
 docker-build:
 	docker build --pull -t ${IMAGE_URL} .
 
 docker-push: docker-build
-	docker tag "${IMAGE_URL}" "${BASE_IMAGE_URL}:v1.3"
-	docker tag "${IMAGE_URL}" "${BASE_IMAGE_URL}:latest"
 	docker push "${IMAGE_URL}"
-	docker push "${BASE_IMAGE_URL}:v1.3"
-	docker push "${BASE_IMAGE_URL}:latest"
+


### PR DESCRIPTION
See the following for reference: https://github.com/digitalocean/docker-shipit-engine/blob/master/Makefile

Note, I have enabled automatic builds on https://hub.docker.com/r/digitalocean/fluentd. The images will now be tagged based on GitHub release.