### PR TITLE
Move to fluent/fluentd:v1.4.2-1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM fluent/fluentd:v1.3
+FROM fluent/fluentd:v1.4.2-1.0
+
+USER root
 
 RUN apk add --no-cache --update --virtual .build-deps sudo build-base ruby-dev
 


### PR DESCRIPTION
This updates is to Fluentd version `1.4.2`. See https://hub.docker.com/r/fluent/fluentd/ for tags and https://github.com/fluent/fluentd/releases/tag/v1.4.2 for release.