### PR TITLE
Update the Fluentd image and use digests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluent/fluentd:v1.4.2-1.0
+FROM fluent/fluentd:v1.4.2-2.0@sha256:5ec85c9fea825f079f9141f37c454f54fcf9dce95e92e9cccd281ed928e3cf83
 
 USER root
 


### PR DESCRIPTION
Updates us to v1.4.2-2.0 of the Docker image. See https://hub.docker.com/r/fluent/fluentd/ for versioning information.