### PR TITLE
Bump us to version fluent/fluentd:v1.5.1-1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluent/fluentd:v1.4.2-2.0@sha256:5ec85c9fea825f079f9141f37c454f54fcf9dce95e92e9cccd281ed928e3cf83
+FROM fluent/fluentd:v1.5.1-1.0@sha256:31a2e95c5c70f2eb946ce6e6158f86a7663ce4e6062e761f389ec085046174c2
 
 USER root
 


### PR DESCRIPTION
Moves us to fluent/fluentd:v1.5.1-1.0: https://www.fluentd.org/blog/fluentd-v1.5.1-has-been-released
```
~ ❯ docker pull fluent/fluentd:v1.5.1-1.0
v1.5.1-1.0: Pulling from fluent/fluentd
e7c96db7181b: Already exists
52335c517915: Pull complete
c16c589e7b92: Pull complete
f45bb11f0c99: Pull complete
e78f0209dbc6: Pull complete
Digest: sha256:31a2e95c5c70f2eb946ce6e6158f86a7663ce4e6062e761f389ec085046174c2
Status: Downloaded newer image for fluent/fluentd:v1.5.1-1.0
```