### PR TITLE
Update to fluent/fluentd:v1.6.2-1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluent/fluentd:v1.5.1-1.0@sha256:31a2e95c5c70f2eb946ce6e6158f86a7663ce4e6062e761f389ec085046174c2
+FROM fluent/fluentd:v1.6.2-1.0@sha256:17e3e8a268fda02a417addc542bbe60f81834aeb15d12e85d68425def3063892
 
 USER root
 


### PR DESCRIPTION
Bump us to https://github.com/fluent/fluentd/releases/tag/v1.6.2.

See the following release notes:
 * https://www.fluentd.org/blog/fluentd-v1.5.2-has-been-released
 * https://www.fluentd.org/blog/fluentd-v1.6.0-has-been-released
 * https://www.fluentd.org/blog/fluentd-v1.6.2-has-been-released

```
~ ❯ docker pull fluent/fluentd:v1.6.2-1.0
v1.6.2-1.0: Pulling from fluent/fluentd
e7c96db7181b: Already exists
2dc13b9c3b9a: Pull complete
9f1188d2a912: Pull complete
0655e59af7f9: Pull complete
94bf634efed8: Pull complete
Digest: sha256:17e3e8a268fda02a417addc542bbe60f81834aeb15d12e85d68425def3063892
Status: Downloaded newer image for fluent/fluentd:v1.6.2-1.0
```